### PR TITLE
Add `type='str'` to `consul_kv` `value` argument_spec

### DIFF
--- a/clustering/consul_kv.py
+++ b/clustering/consul_kv.py
@@ -253,7 +253,7 @@ def main():
         retrieve=dict(required=False, default=True),
         state=dict(default='present', choices=['present', 'absent']),
         token=dict(required=False, default='anonymous', no_log=True),
-        value=dict(required=False)
+        value=dict(required=False, type='str')
     )
 
     module = AnsibleModule(argument_spec, supports_check_mode=False)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

`consul_kv`
##### ANSIBLE VERSION

```
ansible 2.0.0.2
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

This change makes it so that setting a consul_kv value that is a json list doesn't result in that value being interpreted as a python list when submitting with the consul_api

Fixes #751

Before:

```
failed: [localhost -> localhost] => (item={'value': [{'maxResponseHeaderSize': '64KiB', 'type': 'http', 'port': 8081, 'maxRequestHeaderSize': '64KiB'}], 'key': 'server/adminConnectors'}) => {"failed": true, "item": {"key": "server/adminConnectors", "value": [{"maxRequestHeaderSize": "64KiB", "maxResponseHeaderSize": "64KiB", "port": 8081, "type": "http"}]}, "msg": "value should be None or a string / binary data"}
```

After:

```
changed: [localhost -> localhost] => (item={'value': [{'maxResponseHeaderSize': '64KiB', 'type': 'http', 'port': 8081, 'maxRequestHeaderSize': '64KiB'}], 'key': 'server/adminConnectors'})
```

This resolves the following error when attempting to set a json list as
a value:

```
"msg": "value should be None or a string / binary data"
```
